### PR TITLE
Show right icon for cover-art of PVR recording

### DIFF
--- a/1080i/MyPVRRecordings.xml
+++ b/1080i/MyPVRRecordings.xml
@@ -35,8 +35,8 @@
 						<width>100</width>
 						<height>100</height>
 						<aspectratio>keep</aspectratio>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
-						<visible>!String.Contains(ListItem.Icon,Default)</visible>
+						<texture background="true">$INFO[ListItem.ActualIcon]</texture>
+						<visible>!String.Contains(ListItem.ActualIcon,Default)</visible>
 					</control>
 					<control type="image">
 						<left>10</left>
@@ -44,9 +44,9 @@
 						<width>100</width>
 						<height>100</height>
 						<aspectratio>keep</aspectratio>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture background="true">$INFO[ListItem.ActualIcon]</texture>
 						<colordiffuse>$VAR[ColorTextVar]</colordiffuse>
-						<visible>String.Contains(ListItem.Icon,Default)</visible>
+						<visible>String.Contains(ListItem.ActualIcon,Default)</visible>
 					</control>
 					<control type="label">
 						<left>135</left>
@@ -93,8 +93,8 @@
 						<width>100</width>
 						<height>100</height>
 						<aspectratio>keep</aspectratio>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
-						<visible>!String.Contains(ListItem.Icon,Default)</visible>
+						<texture background="true">$INFO[ListItem.ActualIcon]</texture>
+						<visible>!String.Contains(ListItem.ActualIcon,Default)</visible>
 					</control>
 					<control type="image">
 						<left>10</left>
@@ -102,9 +102,9 @@
 						<width>100</width>
 						<height>100</height>
 						<aspectratio>keep</aspectratio>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture background="true">$INFO[ListItem.ActualIcon]</texture>
 						<colordiffuse>$VAR[ColorTextVar]</colordiffuse>
-						<visible>String.Contains(ListItem.Icon,Default)</visible>
+						<visible>String.Contains(ListItem.ActualIcon,Default)</visible>
 					</control>
 					<control type="label">
 						<left>135</left>


### PR DESCRIPTION
Hi,

Here a commit to fix showing of PVR recording cover-art: The arts are never show. Instead the previews override them. The commit fix it as default skin does (Estury or Confluence). And the preview still displayed in the side box as it was before.