### PR TITLE
Add Start music in fullscreen visualisation mode setting

### DIFF
--- a/1080i/custom_1120_OSDSettings.xml
+++ b/1080i/custom_1120_OSDSettings.xml
@@ -26,6 +26,12 @@
 			<ondown>90200</ondown>
 			<onleft>9001</onleft>
 			<onright>6</onright>
+			<control type="radiobutton" id="90215">
+				<width>1078</width>
+				<label>$LOCALIZE[31950]</label>
+				<onclick>Skin.ToggleSetting(Disable.StartFullscreenVisualisation)</onclick>
+				<selected>!Skin.HasSetting(Disable.StartFullscreenVisualisation)</selected>
+			</control>
 			<control type="button" id="90201">
 				<description>Background Button</description>
 				<width>1078</width>

--- a/1080i/custom_1135_StartMusicFullscreen.xml
+++ b/1080i/custom_1135_StartMusicFullscreen.xml
@@ -1,0 +1,6 @@
+<window type="dialog" id="1135">
+    <allowoverlay>false</allowoverlay>
+    <onload condition="!Window.IsActive(visualisation)">FullScreen</onload>
+    <visible>Player.HasAudio + !SubString(Window(videolibrary).Property(TvTunesIsAlive),True + !Skin.HasSetting(Disable.StartFullscreenVisualisation)</visible> 
+    <controls></controls>
+</window>

--- a/1080i/custom_1135_StartMusicFullscreen.xml
+++ b/1080i/custom_1135_StartMusicFullscreen.xml
@@ -1,6 +1,6 @@
 <window type="dialog" id="1135">
     <allowoverlay>false</allowoverlay>
     <onload condition="!Window.IsActive(visualisation)">FullScreen</onload>
-    <visible>Player.HasAudio + !SubString(Window(videolibrary).Property(TvTunesIsAlive),True + !Skin.HasSetting(Disable.StartFullscreenVisualisation)</visible> 
+    <visible>Player.HasAudio + !SubString(Window(videolibrary).Property(TvTunesIsAlive),True) + !Skin.HasSetting(Disable.StartFullscreenVisualisation)</visible> 
     <controls></controls>
 </window>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1324,7 +1324,11 @@ msgctxt "#31949"
 msgid "Roboto 2014"
 msgstr ""
 
-#empty strings from id 31950 to 31957
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr ""
+
+#empty strings from id 31951 to 31957
 
 msgctxt "#31958"
 msgid "Movie"

--- a/language/resource.language.en_us/strings.po
+++ b/language/resource.language.en_us/strings.po
@@ -1288,6 +1288,10 @@ msgctxt "#31949"
 msgid "Roboto 2014"
 msgstr "Roboto 2014"
 
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Start playback in full screen visualisation mode"
+
 msgctxt "#31958"
 msgid "Movie"
 msgstr "Movie"

--- a/language/resource.language.fi_fi/strings.po
+++ b/language/resource.language.fi_fi/strings.po
@@ -672,6 +672,10 @@ msgctxt "#31946"
 msgid "The images selected here will show in the corresponding section if no fanart is available."
 msgstr "Valitut kuvat on käytössä vastaavassa osiossa  jos fanitaidetta ei ole saatavilla."
 
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Aloita toisto koko näytön visualisointi tilassa"
+
 msgctxt "#31958"
 msgid "Movie"
 msgstr "Elokuva"

--- a/language/resource.language.fr_ca/strings.po
+++ b/language/resource.language.fr_ca/strings.po
@@ -1140,6 +1140,10 @@ msgctxt "#31949"
 msgid "Roboto 2014"
 msgstr "Roboto 2014"
 
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Démarrer la lecture en mode de visualisation plein écran"
+
 msgctxt "#31958"
 msgid "Movie"
 msgstr "Films"

--- a/language/resource.language.lt_lt/strings.po
+++ b/language/resource.language.lt_lt/strings.po
@@ -1280,6 +1280,10 @@ msgctxt "#31949"
 msgid "Roboto 2014"
 msgstr "Roboto 2014"
 
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Pradėti atkūrimą per visą ekraną vizualizacijos režimu"
+
 msgctxt "#31958"
 msgid "Movie"
 msgstr "Filmas"

--- a/language/resource.language.ms_my/strings.po
+++ b/language/resource.language.ms_my/strings.po
@@ -1248,6 +1248,10 @@ msgctxt "#31949"
 msgid "Roboto 2014"
 msgstr "Roboto 2014"
 
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Mulakan main balik dalam mod visualisasi skrin penuh"
+
 msgctxt "#31958"
 msgid "Movie"
 msgstr "Cereka"

--- a/language/resource.language.tr_tr/strings.po
+++ b/language/resource.language.tr_tr/strings.po
@@ -1280,6 +1280,10 @@ msgctxt "#31949"
 msgid "Roboto 2014"
 msgstr "Roboto 2014"
 
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Tam ekran görselleştirme modunda oynatmayı başlatın"
+
 msgctxt "#31958"
 msgid "Movie"
 msgstr "Film"


### PR DESCRIPTION
Hi braz96. The following code adds the option for music to launch in fullscreen visualization mode when playback starts. I have been using this code along with the Artist Slideshow set as the background with mimic (jarvis) for about a year and feel it is time to upload and share the code. (also so that when updates happen I wont have to keep re-adding it .. hehe.) 