### PR TITLE
Add Start music in fullscreen visualisation mode setting

### DIFF
--- a/1080i/custom_1120_OSDSettings.xml
+++ b/1080i/custom_1120_OSDSettings.xml
@@ -26,6 +26,12 @@
 			<ondown>90200</ondown>
 			<onleft>9001</onleft>
 			<onright>6</onright>
+			<control type="radiobutton" id="90215">
+				<width>1078</width>
+				<label>$LOCALIZE[31950]</label>
+				<onclick>Skin.ToggleSetting(Disable.StartFullscreenVisualisation)</onclick>
+				<selected>!Skin.HasSetting(Disable.StartFullscreenVisualisation)</selected>
+			</control>
 			<control type="button" id="90201">
 				<description>Background Button</description>
 				<width>1074</width>

--- a/1080i/custom_1135_StartMusicFullscreen.xml
+++ b/1080i/custom_1135_StartMusicFullscreen.xml
@@ -1,0 +1,6 @@
+<window type="dialog" id="1135">
+    <allowoverlay>false</allowoverlay>
+    <onload condition="!Window.IsActive(visualisation)">FullScreen</onload>
+    <visible>Player.HasAudio + !SubString(Window(videolibrary).Property(TvTunesIsAlive),True + !Skin.HasSetting(Disable.StartFullscreenVisualisation)</visible> 
+    <controls></controls>
+</window>

--- a/1080i/custom_1135_StartMusicFullscreen.xml
+++ b/1080i/custom_1135_StartMusicFullscreen.xml
@@ -1,6 +1,6 @@
 <window type="dialog" id="1135">
     <allowoverlay>false</allowoverlay>
     <onload condition="!Window.IsActive(visualisation)">FullScreen</onload>
-    <visible>Player.HasAudio + !SubString(Window(videolibrary).Property(TvTunesIsAlive),True + !Skin.HasSetting(Disable.StartFullscreenVisualisation)</visible> 
+    <visible>Player.HasAudio + !SubString(Window(videolibrary).Property(TvTunesIsAlive),True) + !Skin.HasSetting(Disable.StartFullscreenVisualisation)</visible> 
     <controls></controls>
 </window>

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1381,3 +1381,7 @@ msgstr ""
 msgctxt "#31949"
 msgid "Roboto"
 msgstr ""
+
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr ""

--- a/language/resource.language.en_us/strings.po
+++ b/language/resource.language.en_us/strings.po
@@ -1335,3 +1335,7 @@ msgstr "Arial"
 msgctxt "#31949"
 msgid "Roboto"
 msgstr "Roboto"
+
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Start playback in full screen visualisation mode"

--- a/language/resource.language.fi_fi/strings.po
+++ b/language/resource.language.fi_fi/strings.po
@@ -1231,3 +1231,7 @@ msgstr "Arial"
 msgctxt "#31949"
 msgid "Roboto"
 msgstr "Roboto"
+
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Aloita toisto koko näytön visualisointi tilassa"

--- a/language/resource.language.fr_ca/strings.po
+++ b/language/resource.language.fr_ca/strings.po
@@ -1323,3 +1323,7 @@ msgstr "Arial"
 msgctxt "#31949"
 msgid "Roboto"
 msgstr "Roboto"
+
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Démarrer la lecture en mode de visualisation plein écran"

--- a/language/resource.language.lt_lt/strings.po
+++ b/language/resource.language.lt_lt/strings.po
@@ -1323,3 +1323,7 @@ msgstr "Arial"
 msgctxt "#31949"
 msgid "Roboto"
 msgstr "Roboto"
+
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Pradėti atkūrimą per visą ekraną vizualizacijos režimu"

--- a/language/resource.language.ms_my/strings.po
+++ b/language/resource.language.ms_my/strings.po
@@ -1283,3 +1283,7 @@ msgstr "Arial"
 msgctxt "#31949"
 msgid "Roboto"
 msgstr "Roboto"
+
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Mulakan main balik dalam mod visualisasi skrin penuh"

--- a/language/resource.language.tr_tr/strings.po
+++ b/language/resource.language.tr_tr/strings.po
@@ -1267,3 +1267,7 @@ msgstr "Arial"
 msgctxt "#31949"
 msgid "Roboto"
 msgstr "Roboto"
+
+msgctxt "#31950"
+msgid "Start playback in full screen visualisation mode"
+msgstr "Tam ekran görselleştirme modunda oynatmayı başlatın"


### PR DESCRIPTION
Hi braz96. The following code adds the option for music to launch in fullscreen visualization mode when playback starts. I have been using this code along with the Artist Slideshow set as the background with mimic (jarvis) for about a year and feel it is time to upload and share the code. (also so that when updates happen I wont have to keep re-adding it .. hehe.) 
I have submitted the changes for jarvis and now for the main branch as well.
Thanks