### PR TITLE
Changes from "play" to "pause" on video controls

### DIFF
--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -143,7 +143,7 @@
 					<width>100</width>
 					<height>64</height>
 					<font>IconSmall</font>
-					<usealttexture>Player.Paused | Player.Forwarding | Player.Rewinding</usealttexture>
+					<usealttexture>Player.Playing | Player.Forwarding | Player.Rewinding</usealttexture>
 					<onclick>PlayerControl(Play)</onclick>
 					<visible>Player.PauseEnabled</visible>
 				</control>


### PR DESCRIPTION
I think control buttons should reflect their actions. With this PR I suggest to replace "play" button by "pause" button when the video is already playing.

I didn't test music controls or ay other media. I could test only video controls. Let me know if you want me to add more changes in this PR regarding other player controls.

Thanks!